### PR TITLE
Dynamically support more than 256 tiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ build
 *.launch
 bin
 run
+
+#VSCode
+.vscode

--- a/src/main/java/io/github/minecraftcursedlegacy/impl/registry/ItemTypeRegistry.java
+++ b/src/main/java/io/github/minecraftcursedlegacy/impl/registry/ItemTypeRegistry.java
@@ -64,7 +64,7 @@ class ItemTypeRegistry extends Registry<ItemType> {
 	 */
 	@Override
 	public <E extends ItemType> E register(Id id, IntFunction<E> valueProvider) {
-		return super.register(id, rawSID -> valueProvider.apply(rawSID - 256));
+		return super.register(id, rawSID -> valueProvider.apply(rawSID - Tile.BY_ID.length));
 	}
 
 	@Override
@@ -153,7 +153,7 @@ class ItemTypeRegistry extends Registry<ItemType> {
 	@Override
 	protected void addNewValues(List<Entry<Id, ItemType>> unmapped, CompoundTag tag) {
 		int serialisedTileId = 1;
-		int serialisedItemId = 256;
+		int serialisedItemId = Tile.BY_ID.length;
 
 		for (Entry<Id, ItemType> entry : unmapped) {
 			ItemType value = entry.getValue();
@@ -183,7 +183,7 @@ class ItemTypeRegistry extends Registry<ItemType> {
 	}
 
 	TileItem addTileItem(Id id, Tile tile, BiFunction<Integer, Tile, TileItem> constructor) {
-		TileItem item = constructor.apply(tile.id - 256, tile);
+		TileItem item = constructor.apply(tile.id - Tile.BY_ID.length, tile);
 		this.byRegistryId.put(id, item);
 		this.bySerialisedId.put(item.id, item);
 		return item;

--- a/src/main/java/io/github/minecraftcursedlegacy/impl/registry/RegistryImpl.java
+++ b/src/main/java/io/github/minecraftcursedlegacy/impl/registry/RegistryImpl.java
@@ -13,7 +13,7 @@ import net.minecraft.item.TileItem;
 import net.minecraft.tile.Tile;
 
 public class RegistryImpl implements ModInitializer {
-	private static int currentItemtypeId = 256;
+	private static int currentItemtypeId = Tile.BY_ID.length;
 	private static int currentTileId = 1;
 
 	static final Map<Tile, ItemType> T_2_TI = new HashMap<>();


### PR DESCRIPTION
I removed hard coded values of 256 and made them use ``Tile.BY_ID.length`` instead, ensuring that earlier changes there will reflect in the later functionality of the API.