### PR TITLE
Improve Registry

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,6 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=392aab7
 
 # Mod Properties
-	mod_version = 0.2.1
+	mod_version = 0.3.1
 	maven_group = io.github.minecraftcursedlegacy.api
 	archives_base_name = cursed-legacy-api

--- a/src/main/java/io/github/minecraftcursedlegacy/api/registry/Registry.java
+++ b/src/main/java/io/github/minecraftcursedlegacy/api/registry/Registry.java
@@ -247,19 +247,43 @@ public class Registry<T> implements Iterable<T> {
 		RegistryRemapper.registries().forEach(r -> r.locked = true);
 	}
 
+	/**
+	 *
+	 * @return all objects stored in this registry.
+	 */
+	public Set<T> values() {
+		return this.byRegistryId.values();
+	}
+
+	/**
+	 *
+	 * @return the ids of all objects stored in this registry.
+	 */
+	public Set<Id> ids() {
+		return this.byRegistryId.keySet();
+	}
+
+	/**
+	 *
+	 * @return the serialised ids of all objects stored in this registry
+	 */
+	public Set<Integer> serialisedIds() {
+		return this.bySerialisedId.keySet();
+	}
+
 	@Override
 	@Nonnull
 	public Iterator<T> iterator() {
-		return this.byRegistryId.values().iterator();
+		return values().iterator();
 	}
 
 	@Override
 	public void forEach(Consumer<? super T> consumer) {
-		this.byRegistryId.values().forEach(consumer);
+		values().forEach(consumer);
 	}
 
 	@Override
 	public Spliterator<T> spliterator() {
-		return this.byRegistryId.values().spliterator();
+		return values().spliterator();
 	}
 }

--- a/src/main/java/io/github/minecraftcursedlegacy/api/registry/Registry.java
+++ b/src/main/java/io/github/minecraftcursedlegacy/api/registry/Registry.java
@@ -1,18 +1,16 @@
 package io.github.minecraftcursedlegacy.api.registry;
 
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import io.github.minecraftcursedlegacy.impl.registry.RegistryRemapper;
+import net.minecraft.util.io.CompoundTag;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.function.Consumer;
 import java.util.function.IntFunction;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
-import com.google.common.collect.BiMap;
-import com.google.common.collect.HashBiMap;
-
-import io.github.minecraftcursedlegacy.impl.registry.RegistryRemapper;
-import net.minecraft.util.io.CompoundTag;
 
 /**
  * Registry for game content.
@@ -88,7 +86,7 @@ public class Registry<T> implements Iterable<T> {
 	}
 
 	/**
-	 * Looks up the id in the registy.
+	 * Looks up the id in the registry.
 	 * @param id the specified id to look up in the registry.
 	 * @return the value specified by the id in the registry, if it exists. Otherwise returns the default value.
 	 */
@@ -98,8 +96,8 @@ public class Registry<T> implements Iterable<T> {
 	}
 
 	/**
-	 * Looks up the id of the value in the registy.
-	 * @param id the specified id to look up in the registry.
+	 * Looks up the id of the value in the registry.
+	 * @param value the specified value to find the id of.
 	 * @return the id of the value in the registry, if it exists. Otherwise returns null.
 	 */
 	@Nullable
@@ -108,7 +106,7 @@ public class Registry<T> implements Iterable<T> {
 	}
 
 	/**
-	 * Looks up the int serialised id in the registy.
+	 * Looks up the int serialised id in the registry.
 	 * @param serialisedId the specified serialised id to look up in the registry.
 	 * @return the value specified by the serialised id in the registry, if it exists. Otherwise returns the default value.
 	 */
@@ -117,8 +115,8 @@ public class Registry<T> implements Iterable<T> {
 	}
 
 	/**
-	 * Looks up the int serialised id of the value in the registy.
-	 * @param id the specified serialised id to look up in the registry.
+	 * Looks up the int serialised id of the value in the registry.
+	 * @param value the specified value to find the serialised id of.
 	 * @return the int serialised id of the value in the registry, if it exists. Otherwise returns null.
 	 */
 	public int getSerialisedId(T value) {

--- a/src/main/java/io/github/minecraftcursedlegacy/api/registry/Registry.java
+++ b/src/main/java/io/github/minecraftcursedlegacy/api/registry/Registry.java
@@ -1,11 +1,11 @@
 package io.github.minecraftcursedlegacy.api.registry;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
+import java.util.function.Consumer;
 import java.util.function.IntFunction;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import com.google.common.collect.BiMap;
@@ -17,7 +17,7 @@ import net.minecraft.util.io.CompoundTag;
 /**
  * Registry for game content.
  */
-public class Registry<T> {
+public class Registry<T> implements Iterable<T> {
 	/**
 	 * Creates a new registry object.
 	 * @param clazz the class of the values in this registry.
@@ -247,5 +247,21 @@ public class Registry<T> {
 	 */
 	public static void lockAll() {
 		RegistryRemapper.registries().forEach(r -> r.locked = true);
+	}
+
+	@Override
+	@Nonnull
+	public Iterator<T> iterator() {
+		return this.byRegistryId.values().iterator();
+	}
+
+	@Override
+	public void forEach(Consumer<? super T> consumer) {
+		this.byRegistryId.values().forEach(consumer);
+	}
+
+	@Override
+	public Spliterator<T> spliterator() {
+		return this.byRegistryId.values().spliterator();
 	}
 }

--- a/src/main/java/io/github/minecraftcursedlegacy/api/registry/Registry.java
+++ b/src/main/java/io/github/minecraftcursedlegacy/api/registry/Registry.java
@@ -265,7 +265,7 @@ public class Registry<T> implements Iterable<T> {
 
 	/**
 	 *
-	 * @return the serialised ids of all objects stored in this registry
+	 * @return the serialised ids of all objects stored in this registry.
 	 */
 	public Set<Integer> serialisedIds() {
 		return this.bySerialisedId.keySet();
@@ -274,16 +274,16 @@ public class Registry<T> implements Iterable<T> {
 	@Override
 	@Nonnull
 	public Iterator<T> iterator() {
-		return values().iterator();
+		return this.values().iterator();
 	}
 
 	@Override
 	public void forEach(Consumer<? super T> consumer) {
-		values().forEach(consumer);
+		this.values().forEach(consumer);
 	}
 
 	@Override
 	public Spliterator<T> spliterator() {
-		return values().spliterator();
+		return this.values().spliterator();
 	}
 }


### PR DESCRIPTION
Registry implementing Iterable mirrors how modern vanilla Registry does. It's useful for those of us who need to do something to every registered Tile/ItemType. I also added values(), ids(), and serialisedIds() functions.