### PR TITLE
Add Translation API

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,6 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=392aab7
 
 # Mod Properties
-	mod_version = 0.4.0
+	mod_version = 0.4.1
 	maven_group = io.github.minecraftcursedlegacy.api
 	archives_base_name = cursed-legacy-api

--- a/src/main/java/io/github/minecraftcursedlegacy/accessor/AccessorTranslationStorage.java
+++ b/src/main/java/io/github/minecraftcursedlegacy/accessor/AccessorTranslationStorage.java
@@ -1,0 +1,14 @@
+package io.github.minecraftcursedlegacy.accessor;
+
+import java.util.Properties;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.client.resource.language.TranslationStorage;
+
+@Mixin(TranslationStorage.class)
+public interface AccessorTranslationStorage {
+	@Accessor
+	Properties getTranslations();
+}

--- a/src/main/java/io/github/minecraftcursedlegacy/api/registry/TileItems.java
+++ b/src/main/java/io/github/minecraftcursedlegacy/api/registry/TileItems.java
@@ -34,6 +34,8 @@ public class TileItems {
 	 * @param tile The tile the item is for
 	 *
 	 * @return An item for the given tile
+	 *
+	 * @since 0.4.1
 	 */
 	public static ItemType registerTileItem(Id id, Tile tile) {
 		return registerTileItem(id, tile, PlaceableTileItem::new);
@@ -47,6 +49,8 @@ public class TileItems {
 	 * @param itemFactory A factory for creating the item, given the item ID to use
 	 *
 	 * @return An item for the given tile
+	 *
+	 * @since 0.4.1
 	 */
 	public static <I extends PlaceableTileItem> I registerTileItem(Id id, Tile tile, IntFunction<I> itemFactory) {
 		return RegistryImpl.addTileItem(id, tile, itemFactory);

--- a/src/main/java/io/github/minecraftcursedlegacy/api/registry/TileItems.java
+++ b/src/main/java/io/github/minecraftcursedlegacy/api/registry/TileItems.java
@@ -1,8 +1,13 @@
 package io.github.minecraftcursedlegacy.api.registry;
 
-import io.github.minecraftcursedlegacy.impl.registry.RegistryImpl;
+import java.util.function.IntFunction;
+
+import net.minecraft.item.ItemType;
+import net.minecraft.item.PlaceableTileItem;
 import net.minecraft.item.TileItem;
 import net.minecraft.tile.Tile;
+
+import io.github.minecraftcursedlegacy.impl.registry.RegistryImpl;
 
 /**
  * Utilities for adding and registering tile items.
@@ -13,8 +18,37 @@ public class TileItems {
 	 * @param id the id of the tile item.
 	 * @param value the tile this tile item is for.
 	 * @return the tile item created.
+	 * @deprecated Prefer using {@link #registerTileItem(Id, Tile)} (which creates a 
+	 * 				{@link PlaceableTileItem} for the given tile rather than a {@link TileItem}) so 
+	 * 				that it will respect the item meta when deciding on the tile to place in the world.
 	 */
+	@Deprecated
 	public static TileItem addRegisteredTileItem(Id id, Tile value) {
-		return RegistryImpl.addTileItem(id, value, TileItem::new);
+		return RegistryImpl.addTileItem(id, value, itemID -> new TileItem(itemID, value));
+	}
+
+	/**
+	 * Register an {@link ItemType} for the given {@link Tile}.
+	 *
+	 * @param id The identifier of the item to be registered
+	 * @param tile The tile the item is for
+	 *
+	 * @return An item for the given tile
+	 */
+	public static ItemType registerTileItem(Id id, Tile tile) {
+		return registerTileItem(id, tile, PlaceableTileItem::new);
+	}
+
+	/**
+	 * Register an {@link ItemType} for the given {@link Tile} created using the given factory.
+	 *
+	 * @param id The identifier of the item to be registered
+	 * @param tile The tile the item is for
+	 * @param itemFactory A factory for creating the item, given the item ID to use
+	 *
+	 * @return An item for the given tile
+	 */
+	public static <I extends PlaceableTileItem> I registerTileItem(Id id, Tile tile, IntFunction<I> itemFactory) {
+		return RegistryImpl.addTileItem(id, tile, itemFactory);
 	}
 }

--- a/src/main/java/io/github/minecraftcursedlegacy/api/registry/Translations.java
+++ b/src/main/java/io/github/minecraftcursedlegacy/api/registry/Translations.java
@@ -16,6 +16,7 @@ import io.github.minecraftcursedlegacy.accessor.AccessorTranslationStorage;
  * Utilities for adding translations for things.
  *
  * @see I18n Accessing the translations
+ * @since 0.4.1
  *
  * @author Chocohead
  */

--- a/src/main/java/io/github/minecraftcursedlegacy/api/registry/Translations.java
+++ b/src/main/java/io/github/minecraftcursedlegacy/api/registry/Translations.java
@@ -1,0 +1,113 @@
+package io.github.minecraftcursedlegacy.api.registry;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+
+import net.minecraft.achievement.Achievement;
+import net.minecraft.client.resource.language.I18n;
+import net.minecraft.client.resource.language.TranslationStorage;
+import net.minecraft.item.ItemType;
+import net.minecraft.tile.Tile;
+
+import io.github.minecraftcursedlegacy.accessor.AccessorTranslationStorage;
+
+/**
+ * Utilities for adding translations for things.
+ *
+ * @see I18n Accessing the translations
+ *
+ * @author Chocohead
+ */
+public final class Translations {
+	private Translations() {
+	}
+
+	/**
+	 * Add a translation for the given {@link Tile}.
+	 *
+	 * @param tile The tile to add the translation for
+	 * @param translation The translated name for the tile
+	 *
+	 * @throws IllegalArgumentException If the given tile has not had {@link Tile#setName(String)} called
+	 */
+	public static void addTileTranslation(Tile tile, String translation) {
+		if (tile.method_1597() == null) throw new IllegalArgumentException("Given tile doesn't have a name: " + tile);
+		addTranslation(tile.method_1597().concat(".name"), translation);
+	}
+
+	/**
+	 * Add translation for the given {@link ItemType}.
+	 * 
+	 * @param item The item to add the translation for
+	 * @param translation The translated name for the item
+	 *
+	 * @throws IllegalArgumentException If the given item has not had {@link ItemType#setName(String)} called
+	 */
+	public static void addItemTranslation(ItemType item, String translation) {
+		if (item.getTranslationKey() == null) throw new IllegalArgumentException("Given item doesn't have a name: " + item);
+		addTranslation(item.getTranslationKey().concat(".name"), translation);
+	}
+
+	/**
+	 * Add a translation for an {@link Achievement} with the given name.
+	 * <p>
+	 * Make sure to call this <i>before</i> the Achievement is constructed!
+	 *
+	 * @param key The name of the achievement as given to the constructor 
+	 * @param translation The translated name for the achievement
+	 *
+	 * @see #addAchievementDescriptionTranslation(String, String)
+	 */
+	public static void addAchievementTranslation(String key, String translation) {
+		addTranslation("achievement.".concat(key), translation);
+	}
+
+	/**
+	 * Add a translation for an {@link Achievement}'s description with the given name.
+	 * <p>
+	 * Make sure to call this <i>before</i> the Achievement is constructed!
+	 *
+	 * @param key The name of the achievement as given to the constructor 
+	 * @param translation The translated name for the achievement's description
+	 *
+	 * @see #addAchievementTranslation(String, String)
+	 */
+	public static void addAchievementDescriptionTranslation(String key, String translation) {
+		addTranslation("achievement." + key + ".desc", translation);
+	}
+
+	/**
+	 * Add a translation for the given key.
+	 *
+	 * @param key The raw translation key
+	 * @param translation The translated text for the key
+	 */
+	public static void addTranslation(String key, String translation) {
+		((AccessorTranslationStorage) TranslationStorage.getInstance()).getTranslations().put(key, translation);
+	}
+
+	/**
+	 * Add all the translations from the given lang file.
+	 *
+	 * @param file The location of the lang file to load translations from
+	 *
+	 * @throws IOException If there is an error reading the file
+	 */
+	public static void loadLangFile(String file) throws IOException {
+		try (InputStream in = Translations.class.getResourceAsStream(file)) {
+			((AccessorTranslationStorage) TranslationStorage.getInstance()).getTranslations().load(in);
+		}
+	}
+
+	/**
+	 * Add all the translations from the given {@link Reader}.
+	 *
+	 * @param reader A reader containing translations to read from, not closed after use
+	 *
+	 * @throws IOException If there is an error reading the translations
+	 */
+	public static void loadLangFile(Reader reader) throws IOException {
+		((AccessorTranslationStorage) TranslationStorage.getInstance()).getTranslations().load(reader);
+	}
+}

--- a/src/main/java/io/github/minecraftcursedlegacy/api/registry/Translations.java
+++ b/src/main/java/io/github/minecraftcursedlegacy/api/registry/Translations.java
@@ -51,8 +51,8 @@ public final class Translations {
 
 	/**
 	 * Add a translation for an {@link Achievement} with the given name.
-	 * <p>
-	 * Make sure to call this <i>before</i> the Achievement is constructed!
+	 *
+	 * <p>Make sure to call this <i>before</i> the Achievement is constructed!
 	 *
 	 * @param key The name of the achievement as given to the constructor 
 	 * @param translation The translated name for the achievement
@@ -65,8 +65,8 @@ public final class Translations {
 
 	/**
 	 * Add a translation for an {@link Achievement}'s description with the given name.
-	 * <p>
-	 * Make sure to call this <i>before</i> the Achievement is constructed!
+	 *
+	 * <p>Make sure to call this <i>before</i> the Achievement is constructed!
 	 *
 	 * @param key The name of the achievement as given to the constructor 
 	 * @param translation The translated name for the achievement's description

--- a/src/main/java/io/github/minecraftcursedlegacy/impl/registry/ItemTypeRegistry.java
+++ b/src/main/java/io/github/minecraftcursedlegacy/impl/registry/ItemTypeRegistry.java
@@ -2,16 +2,8 @@ package io.github.minecraftcursedlegacy.impl.registry;
 
 import java.util.List;
 import java.util.Map.Entry;
-import java.util.function.BiFunction;
 import java.util.function.IntFunction;
 
-import io.github.minecraftcursedlegacy.accessor.AccessorPlaceableTileItem;
-import io.github.minecraftcursedlegacy.accessor.AccessorRecipeRegistry;
-import io.github.minecraftcursedlegacy.accessor.AccessorShapedRecipe;
-import io.github.minecraftcursedlegacy.accessor.AccessorShapelessRecipe;
-import io.github.minecraftcursedlegacy.accessor.AccessorTileItem;
-import io.github.minecraftcursedlegacy.api.registry.Id;
-import io.github.minecraftcursedlegacy.api.registry.Registry;
 import net.minecraft.item.ItemInstance;
 import net.minecraft.item.ItemType;
 import net.minecraft.item.PlaceableTileItem;
@@ -22,6 +14,14 @@ import net.minecraft.recipe.ShapedRecipe;
 import net.minecraft.recipe.ShapelessRecipe;
 import net.minecraft.tile.Tile;
 import net.minecraft.util.io.CompoundTag;
+
+import io.github.minecraftcursedlegacy.accessor.AccessorPlaceableTileItem;
+import io.github.minecraftcursedlegacy.accessor.AccessorRecipeRegistry;
+import io.github.minecraftcursedlegacy.accessor.AccessorShapedRecipe;
+import io.github.minecraftcursedlegacy.accessor.AccessorShapelessRecipe;
+import io.github.minecraftcursedlegacy.accessor.AccessorTileItem;
+import io.github.minecraftcursedlegacy.api.registry.Id;
+import io.github.minecraftcursedlegacy.api.registry.Registry;
 
 class ItemTypeRegistry extends Registry<ItemType> {
 	ItemTypeRegistry(Id registryName) {
@@ -182,8 +182,8 @@ class ItemTypeRegistry extends Registry<ItemType> {
 		}
 	}
 
-	TileItem addTileItem(Id id, Tile tile, BiFunction<Integer, Tile, TileItem> constructor) {
-		TileItem item = constructor.apply(tile.id - Tile.BY_ID.length, tile);
+	<I extends ItemType> I addTileItem(Id id, Tile tile, IntFunction<I> constructor) {
+		I item = constructor.apply(tile.id - Tile.BY_ID.length);
 		this.byRegistryId.put(id, item);
 		this.bySerialisedId.put(item.id, item);
 		return item;

--- a/src/main/java/io/github/minecraftcursedlegacy/impl/registry/ItemTypeRegistry.java
+++ b/src/main/java/io/github/minecraftcursedlegacy/impl/registry/ItemTypeRegistry.java
@@ -186,6 +186,7 @@ class ItemTypeRegistry extends Registry<ItemType> {
 		I item = constructor.apply(tile.id - Tile.BY_ID.length);
 		this.byRegistryId.put(id, item);
 		this.bySerialisedId.put(item.id, item);
+		RegistryImpl.T_2_TI.put(tile, item);
 		return item;
 	}
 }

--- a/src/main/java/io/github/minecraftcursedlegacy/impl/registry/RegistryImpl.java
+++ b/src/main/java/io/github/minecraftcursedlegacy/impl/registry/RegistryImpl.java
@@ -1,17 +1,18 @@
 package io.github.minecraftcursedlegacy.impl.registry;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.IntFunction;
+
+import net.minecraft.item.ItemType;
+import net.minecraft.tile.Tile;
+
+import net.fabricmc.api.ModInitializer;
+
 import io.github.minecraftcursedlegacy.accessor.AccessorEntityRegistry;
 import io.github.minecraftcursedlegacy.api.registry.Id;
 import io.github.minecraftcursedlegacy.api.registry.Registry;
 import io.github.minecraftcursedlegacy.impl.Hacks;
-import net.fabricmc.api.ModInitializer;
-import net.minecraft.item.ItemType;
-import net.minecraft.item.TileItem;
-import net.minecraft.tile.Tile;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.BiFunction;
 
 public class RegistryImpl implements ModInitializer {
 	private static int currentItemtypeId = Tile.BY_ID.length;
@@ -93,7 +94,7 @@ public class RegistryImpl implements ModInitializer {
 		}
 	}
 
-	public static TileItem addTileItem(Id id, Tile value, BiFunction<Integer, Tile, TileItem> constructor) {
+	public static <I extends ItemType> I addTileItem(Id id, Tile value, IntFunction<I> constructor) {
 		return ((ItemTypeRegistry) ITEM_TYPE).addTileItem(id, value, constructor);
 	}
 

--- a/src/main/resources/api.accessors.json
+++ b/src/main/resources/api.accessors.json
@@ -10,7 +10,8 @@
     "AccessorShapelessRecipe",
     "AccessorTileItem",
     "AccessorAbstractPacket",
-    "AccessorEntityRegistry"
+    "AccessorEntityRegistry",
+    "AccessorTranslationStorage"
   ],
   "client": [
   ],

--- a/src/test/java/io/github/minecraftcursedlegacy/test/RegistryTest.java
+++ b/src/test/java/io/github/minecraftcursedlegacy/test/RegistryTest.java
@@ -18,7 +18,7 @@ public class RegistryTest implements ModInitializer {
 				i -> new BasicItem(i).setTexturePosition(5, 0).setName("exampleItem"));
 		tile = Registries.TILE.register(new Id("modid:tile"),
 				i -> new BasicTile(i).setName("exampleBlock"));
-		tileItem = TileItems.addRegisteredTileItem(new Id("modid:tile"), tile);
+		tileItem = TileItems.registerTileItem(new Id("modid:tile"), tile);
 
 		Recipes.addShapelessRecipe(new ItemInstance(item, 2), Tile.DIRT, Tile.SAND);
 		Recipes.addShapedRecipe(new ItemInstance(tile), "##", '#', Tile.DIRT);

--- a/src/test/java/io/github/minecraftcursedlegacy/test/RegistryTest.java
+++ b/src/test/java/io/github/minecraftcursedlegacy/test/RegistryTest.java
@@ -4,6 +4,7 @@ import io.github.minecraftcursedlegacy.api.recipe.Recipes;
 import io.github.minecraftcursedlegacy.api.registry.Id;
 import io.github.minecraftcursedlegacy.api.registry.Registries;
 import io.github.minecraftcursedlegacy.api.registry.TileItems;
+import io.github.minecraftcursedlegacy.api.registry.Translations;
 import net.fabricmc.api.ModInitializer;
 import net.minecraft.item.ItemInstance;
 import net.minecraft.item.ItemType;
@@ -16,11 +17,14 @@ public class RegistryTest implements ModInitializer {
 		item = Registries.ITEM_TYPE.register(new Id("modid:item"),
 				i -> new BasicItem(i).setTexturePosition(5, 0).setName("exampleItem"));
 		tile = Registries.TILE.register(new Id("modid:tile"),
-				i -> new BasicTile(i));
+				i -> new BasicTile(i).setName("exampleBlock"));
 		tileItem = TileItems.addRegisteredTileItem(new Id("modid:tile"), tile);
 
 		Recipes.addShapelessRecipe(new ItemInstance(item, 2), Tile.DIRT, Tile.SAND);
 		Recipes.addShapedRecipe(new ItemInstance(tile), "##", '#', Tile.DIRT);
+
+		Translations.addTileTranslation(tile, "Example Block");
+		Translations.addItemTranslation(item, "Example Item");
 	}
 
 	public static ItemType item;


### PR DESCRIPTION
Adds a basic API for adding translations to existing tiles or items, as well as achievement names/descriptions before they are made (as they are translated immediately in `Achievement`'s constructor so it's not ideal to do after the fact). Allows for keys to be directly inserted too, or read in from a lang file.

The `TileItems` changes go in hand to fix the fact `TileItem` isn't really designed for being used with all tiles given it doesn't use the given tile's name or texture and will always place meta 0 down even if the stack has something else. The static block in `Tile` uses `PlaceableTileItem` which seems to be the more appropriate choice. Finally it adds mod's tiles to the `RegistryImpl#T_2_TI` map which I think was missed given all of vanilla's tiles end up in there.