### PR TITLE
Add TileEntity registry and TileEntity types

### DIFF
--- a/src/main/java/io/github/minecraftcursedlegacy/accessor/AccessorTileEntity.java
+++ b/src/main/java/io/github/minecraftcursedlegacy/accessor/AccessorTileEntity.java
@@ -1,0 +1,36 @@
+package io.github.minecraftcursedlegacy.accessor;
+
+import net.minecraft.entity.TileEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+import java.util.Map;
+
+@Mixin(TileEntity.class)
+public interface AccessorTileEntity {
+	@Accessor("ID_TO_CLASS")
+	static Map<String, Class<? extends TileEntity>> getIdToClassMap() {
+		throw new AssertionError("mixin");
+	}
+
+	@Accessor("ID_TO_CLASS")
+	static void setIdToClassMap(Map<String, Class<? extends TileEntity>> value) {
+		throw new AssertionError("mixin");
+	}
+
+	@Accessor("CLASS_TO_ID")
+	static Map<Class<? extends TileEntity>, String> getClassToIdMap() {
+		throw new AssertionError("mixin");
+	}
+
+	@Accessor("CLASS_TO_ID")
+	static void setClassToIdMap(Map<Class<? extends TileEntity>, String> value) {
+		throw new AssertionError("mixin");
+	}
+
+	@Invoker("register")
+	static void callRegister(Class<? extends TileEntity> arg, String string) {
+		throw new AssertionError("mixin");
+	}
+}

--- a/src/main/java/io/github/minecraftcursedlegacy/api/registry/Registries.java
+++ b/src/main/java/io/github/minecraftcursedlegacy/api/registry/Registries.java
@@ -2,6 +2,7 @@ package io.github.minecraftcursedlegacy.api.registry;
 
 import io.github.minecraftcursedlegacy.impl.registry.EntityType;
 import io.github.minecraftcursedlegacy.impl.registry.RegistryImpl;
+import io.github.minecraftcursedlegacy.impl.registry.TileEntityType;
 import net.minecraft.item.ItemType;
 import net.minecraft.tile.Tile;
 
@@ -22,4 +23,9 @@ public final class Registries {
 	 * Registry for Entity types.
 	 */
 	public static final Registry<EntityType> ENTITY_TYPE = RegistryImpl.ENTITY_TYPE;
+
+	/**
+	 * Registry for Tile Entity types.
+	 */
+	public static final Registry<TileEntityType> TILE_ENTITY_TYPE = RegistryImpl.TILE_ENTITY_TYPE;
 }

--- a/src/main/java/io/github/minecraftcursedlegacy/api/registry/TileEntityTypes.java
+++ b/src/main/java/io/github/minecraftcursedlegacy/api/registry/TileEntityTypes.java
@@ -9,7 +9,7 @@ public class TileEntityTypes {
 	 * @param clazz the tile entity class.
 	 * @param id the identifier used in the TileEntityType registry.
 	 */
-	public static TileEntityType createTileEntityType(Class<? extends TileEntity> clazz, Id id) {
+	public static TileEntityType create(Class<? extends TileEntity> clazz, Id id) {
 		return new TileEntityType(clazz, id);
 	}
 }

--- a/src/main/java/io/github/minecraftcursedlegacy/api/registry/TileEntityTypes.java
+++ b/src/main/java/io/github/minecraftcursedlegacy/api/registry/TileEntityTypes.java
@@ -1,0 +1,15 @@
+package io.github.minecraftcursedlegacy.api.registry;
+
+import io.github.minecraftcursedlegacy.impl.registry.TileEntityType;
+import net.minecraft.entity.TileEntity;
+
+public class TileEntityTypes {
+	/**
+	 * Use this to create TileEntityTypes for your own tile entities.
+	 * @param clazz the tile entity class.
+	 * @param id the identifier used in the TileEntityType registry.
+	 */
+	public static TileEntityType createTileEntityType(Class<? extends TileEntity> clazz, Id id) {
+		return new TileEntityType(clazz, id);
+	}
+}

--- a/src/main/java/io/github/minecraftcursedlegacy/impl/registry/RegistryImpl.java
+++ b/src/main/java/io/github/minecraftcursedlegacy/impl/registry/RegistryImpl.java
@@ -1,18 +1,17 @@
 package io.github.minecraftcursedlegacy.impl.registry;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.IntFunction;
-
-import net.minecraft.item.ItemType;
-import net.minecraft.tile.Tile;
-
-import net.fabricmc.api.ModInitializer;
-
 import io.github.minecraftcursedlegacy.accessor.AccessorEntityRegistry;
+import io.github.minecraftcursedlegacy.accessor.AccessorTileEntity;
 import io.github.minecraftcursedlegacy.api.registry.Id;
 import io.github.minecraftcursedlegacy.api.registry.Registry;
 import io.github.minecraftcursedlegacy.impl.Hacks;
+import net.fabricmc.api.ModInitializer;
+import net.minecraft.item.ItemType;
+import net.minecraft.tile.Tile;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.IntFunction;
 
 public class RegistryImpl implements ModInitializer {
 	private static int currentItemtypeId = Tile.BY_ID.length;
@@ -106,13 +105,16 @@ public class RegistryImpl implements ModInitializer {
 	public static final Registry<ItemType> ITEM_TYPE;
 	public static final Registry<Tile> TILE;
 	public static final Registry<EntityType> ENTITY_TYPE;
+	public static final Registry<TileEntityType> TILE_ENTITY_TYPE;
 
 	static {
 		//noinspection ResultOfMethodCallIgnored
 		Tile.BED.hashCode(); // make sure tiles are initialised
 		AccessorEntityRegistry.getIdToClassMap(); // make sure entities are initialised
+		AccessorTileEntity.getIdToClassMap(); // make sure tile entities are initialised
 		ITEM_TYPE = new ItemTypeRegistry(new Id("api:item_type"));
 		TILE = new TileRegistry(new Id("api:tile"));
 		ENTITY_TYPE = new EntityTypeRegistry(new Id("api:entity_type"));
+		TILE_ENTITY_TYPE = new TileEntityTypeRegistry(new Id("api:tile_entity_type"));
 	}
 }

--- a/src/main/java/io/github/minecraftcursedlegacy/impl/registry/TileEntityType.java
+++ b/src/main/java/io/github/minecraftcursedlegacy/impl/registry/TileEntityType.java
@@ -18,7 +18,7 @@ public class TileEntityType {
 	}
 
 	/**
-	 * Prefer use of {@link io.github.minecraftcursedlegacy.api.registry.TileEntityTypes#create}
+	 * Prefer use of {@link io.github.minecraftcursedlegacy.api.registry.TileEntityTypes#create}.
 	 */
 	public TileEntityType(Class<? extends TileEntity> clazz, Id id) {
 		this.clazz = clazz;

--- a/src/main/java/io/github/minecraftcursedlegacy/impl/registry/TileEntityType.java
+++ b/src/main/java/io/github/minecraftcursedlegacy/impl/registry/TileEntityType.java
@@ -17,6 +17,9 @@ public class TileEntityType {
 		this.vanillaRegistryStringId = vanillaRegistryStringId;
 	}
 
+	/**
+	 * Prefer use of {@link io.github.minecraftcursedlegacy.api.registry.TileEntityTypes#create}
+	 */
 	public TileEntityType(Class<? extends TileEntity> clazz, Id id) {
 		this.clazz = clazz;
 		this.vanillaRegistryStringId = id.toString();

--- a/src/main/java/io/github/minecraftcursedlegacy/impl/registry/TileEntityType.java
+++ b/src/main/java/io/github/minecraftcursedlegacy/impl/registry/TileEntityType.java
@@ -1,0 +1,36 @@
+package io.github.minecraftcursedlegacy.impl.registry;
+
+import io.github.minecraftcursedlegacy.api.registry.Id;
+import net.minecraft.entity.TileEntity;
+
+public class TileEntityType {
+	private final Class<? extends TileEntity> clazz;
+	private final String vanillaRegistryStringId;
+
+	/**
+	 * Protected constructor used only for vanilla tile entities.
+	 * @param clazz the entity class.
+	 * @param vanillaRegistryStringId the vanilla name of the entity.
+	 */
+	protected TileEntityType(Class<? extends TileEntity> clazz, String vanillaRegistryStringId) {
+		this.clazz = clazz;
+		this.vanillaRegistryStringId = vanillaRegistryStringId;
+	}
+
+	public TileEntityType(Class<? extends TileEntity> clazz, Id id) {
+		this.clazz = clazz;
+		this.vanillaRegistryStringId = id.toString();
+	}
+
+	public Class<? extends TileEntity> getClazz() {
+		return clazz;
+	}
+
+	public String getVanillaRegistryStringId() {
+		return vanillaRegistryStringId;
+	}
+
+	public Id getId() {
+		return new Id(vanillaRegistryStringId);
+	}
+}

--- a/src/main/java/io/github/minecraftcursedlegacy/impl/registry/TileEntityTypeRegistry.java
+++ b/src/main/java/io/github/minecraftcursedlegacy/impl/registry/TileEntityTypeRegistry.java
@@ -1,0 +1,44 @@
+package io.github.minecraftcursedlegacy.impl.registry;
+
+import io.github.minecraftcursedlegacy.accessor.AccessorTileEntity;
+import io.github.minecraftcursedlegacy.api.registry.Id;
+import io.github.minecraftcursedlegacy.api.registry.Registry;
+
+import java.util.HashMap;
+
+public class TileEntityTypeRegistry extends Registry<TileEntityType> {
+	/**
+	 * Creates a new registry object.
+	 *
+	 * @param registryName the identifier for this registry.
+	 */
+	public TileEntityTypeRegistry(Id registryName) {
+		super(TileEntityType.class, registryName, null);
+
+		// add vanilla tile entities
+		AccessorTileEntity.getIdToClassMap().forEach((id, clazz) -> {
+			if (clazz != null) {
+				TileEntityType type = new TileEntityType(clazz, id == null ? "tileentity" : id);
+				if (id == null) {
+					id = "tileentity";
+				} else {
+					id = id.toLowerCase();
+				}
+
+				this.byRegistryId.put(new Id(id), type);
+				this.bySerialisedId.put(getNextSerialisedId(), type);
+			}
+		});
+	}
+
+	@Override
+	protected void beforeRemap() {
+		AccessorTileEntity.setClassToIdMap(new HashMap<>());
+		AccessorTileEntity.setIdToClassMap(new HashMap<>());
+	}
+
+	@Override
+	protected void onRemap(TileEntityType remappedValue, int newSerialisedId) {
+		AccessorTileEntity.callRegister(remappedValue.getClazz(), remappedValue.getVanillaRegistryStringId());
+	}
+}

--- a/src/main/resources/api.accessors.json
+++ b/src/main/resources/api.accessors.json
@@ -11,7 +11,8 @@
     "AccessorTileItem",
     "AccessorAbstractPacket",
     "AccessorEntityRegistry",
-    "AccessorTranslationStorage"
+    "AccessorTranslationStorage",
+    "AccessorTileEntity"
   ],
   "client": [
     "AccessorMinecraft"

--- a/src/test/java/io/github/minecraftcursedlegacy/test/TileEntityTest.java
+++ b/src/test/java/io/github/minecraftcursedlegacy/test/TileEntityTest.java
@@ -1,0 +1,48 @@
+package io.github.minecraftcursedlegacy.test;
+
+import io.github.minecraftcursedlegacy.api.recipe.Recipes;
+import io.github.minecraftcursedlegacy.api.registry.Id;
+import io.github.minecraftcursedlegacy.api.registry.Registries;
+import io.github.minecraftcursedlegacy.api.registry.TileItems;
+import io.github.minecraftcursedlegacy.impl.registry.TileEntityType;
+import io.github.minecraftcursedlegacy.impl.registry.TileEntityTypeRegistry;
+import net.fabricmc.api.ModInitializer;
+import net.minecraft.entity.TileEntity;
+import net.minecraft.item.ItemInstance;
+import net.minecraft.item.ItemType;
+import net.minecraft.tile.Tile;
+import net.minecraft.tile.TileWithEntity;
+import net.minecraft.tile.material.Material;
+
+public class TileEntityTest implements ModInitializer {
+    @Override
+    public void onInitialize() {
+        Tile tile = Registries.TILE.register(new Id("test:tileWithEntity"),
+                i -> new TestTileWithEntity(i).setName("TileWithEntity"));
+        TileItems.registerTileItem(new Id("test:tileWithEntity"), tile);
+
+        Registries.TILE_ENTITY_TYPE.register(new Id("test:tileEntity"), i -> new TileEntityType(TestTileEntity.class, new Id("test:tileEntity")));
+
+        ItemType tileItem = TileItems.registerTileItem(new Id("modid:tile"), tile);
+        Recipes.addShapelessRecipe(new ItemInstance(tileItem), Tile.DIRT, Tile.SAND);
+    }
+
+    private static class TestTileWithEntity extends TileWithEntity {
+        protected TestTileWithEntity(int id) {
+            super(id, Material.METAL);
+        }
+
+        @Override
+        protected TileEntity createTileEntity() {
+            return new TestTileEntity();
+        }
+    }
+
+    private static class TestTileEntity extends TileEntity {
+        @Override
+        public void tick() {
+            super.tick();
+            System.out.println(level.getLevelTime());
+        }
+    }
+}

--- a/src/test/java/io/github/minecraftcursedlegacy/test/TileEntityTest.java
+++ b/src/test/java/io/github/minecraftcursedlegacy/test/TileEntityTest.java
@@ -3,9 +3,8 @@ package io.github.minecraftcursedlegacy.test;
 import io.github.minecraftcursedlegacy.api.recipe.Recipes;
 import io.github.minecraftcursedlegacy.api.registry.Id;
 import io.github.minecraftcursedlegacy.api.registry.Registries;
+import io.github.minecraftcursedlegacy.api.registry.TileEntityTypes;
 import io.github.minecraftcursedlegacy.api.registry.TileItems;
-import io.github.minecraftcursedlegacy.impl.registry.TileEntityType;
-import io.github.minecraftcursedlegacy.impl.registry.TileEntityTypeRegistry;
 import net.fabricmc.api.ModInitializer;
 import net.minecraft.entity.TileEntity;
 import net.minecraft.item.ItemInstance;
@@ -21,7 +20,7 @@ public class TileEntityTest implements ModInitializer {
                 i -> new TestTileWithEntity(i).setName("TileWithEntity"));
         TileItems.registerTileItem(new Id("test:tileWithEntity"), tile);
 
-        Registries.TILE_ENTITY_TYPE.register(new Id("test:tileEntity"), i -> new TileEntityType(TestTileEntity.class, new Id("test:tileEntity")));
+        Registries.TILE_ENTITY_TYPE.register(new Id("test:tileEntity"), i -> TileEntityTypes.create(TestTileEntity.class, new Id("test:tileEntity")));
 
         ItemType tileItem = TileItems.registerTileItem(new Id("modid:tile"), tile);
         Recipes.addShapelessRecipe(new ItemInstance(tileItem), Tile.DIRT, Tile.SAND);

--- a/src/test/resources/fabric.mod.json
+++ b/src/test/resources/fabric.mod.json
@@ -21,7 +21,8 @@
     "init": [
       "io.github.minecraftcursedlegacy.test.RegistryTest",
       "io.github.minecraftcursedlegacy.test.LevelGenTest",
-      "io.github.minecraftcursedlegacy.test.AtlasTest"
+      "io.github.minecraftcursedlegacy.test.AtlasTest",
+      "io.github.minecraftcursedlegacy.test.TileEntityTest"
     ]
   },
 


### PR DESCRIPTION
Based off the entity registry code.

~~!!Untested!! works with vanilla. Not tested with custom mod tile entities.~~ Now includes test mod.